### PR TITLE
Cascading translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "karma-jasmine": "^0.1.5",
     "karma-junit-reporter": "^0.1.0",
     "karma-phantomjs-launcher": "^0.1.4",
-    "karma-requirejs": "^0.1.0",
+    "karma-requirejs": "^0.2.2",
     "karma-script-launcher": "~0.1.0",
     "phantomjs": "^1.9.7-8"
   }

--- a/src/translate.js
+++ b/src/translate.js
@@ -168,6 +168,12 @@ angular.module('MRS.i18n').service('translate', ['$log', '$timeout', function mr
             count = 0,
             i;
         
+        function getDescendantProp(obj, desc) {
+            var arr = desc.split(".");
+            while(arr.length && (obj = obj[arr.shift()]));
+            return obj;
+        }
+        
         if (term) {
             if (!language) {
                 language = selectedLanguage;
@@ -176,8 +182,7 @@ angular.module('MRS.i18n').service('translate', ['$log', '$timeout', function mr
             if (!language) {
                 $log.error('There must be a default language defined for the application.');
             } else {
-                if (resources[language] && resources[language][term]) {
-                    translation = resources[language][term];
+                if (resources[language] && (translation = getDescendantProp(resources[language], term))) {
                     translationFound = true;
                 }
                 
@@ -189,8 +194,7 @@ angular.module('MRS.i18n').service('translate', ['$log', '$timeout', function mr
                     
                     language = defaultLanguage;
                     
-                    if (resources[language] && resources[language][term]) {
-                        translation = resources[language][term];
+                    if (resources[language] && (translation = getDescendantProp(resources[language], term))) {
                         translationFound = true;
                     }
                     

--- a/test/unit/test.translate.js
+++ b/test/unit/test.translate.js
@@ -237,6 +237,41 @@ describe('MRS.i18n:', function () {
             
             expect(translateService.getTerm('message', null, 1, 2)).toBe('Parametro 1 e parametro 2.');
         });
+        
+        it('should resolve cascade translation files', function() {
+             translateService.setDefaultLanguage('pt-pt');
+            
+            // defining response
+            fakeServer.requests[0].respond(200, {
+                "Content-Type": "application/json"
+            }, JSON.stringify({
+                message: {
+                    mA: "MSG 1",
+                    mB: "MSG 2"
+                }
+            }));
+            
+            expect(translateService.getTerm('message.mA')).toEqual('MSG 1');
+            expect(translateService.getTerm('message.mB')).toEqual('MSG 2');
+        });
+        
+        it('should not work when term is not found in cascade translation files', function() {
+             translateService.setDefaultLanguage('pt-pt');
+            
+            // defining response
+            fakeServer.requests[0].respond(200, {
+                "Content-Type": "application/json"
+            }, JSON.stringify({
+                message: {
+                    mA: "MSG 1",
+                    mB: "MSG 2"
+                }
+            }));
+            
+            expect(translateService.getTerm('wrongMessage')).toEqual(null);
+            expect(translateService.getTerm('message.mC')).toEqual(null);
+            expect(logService.warn).toHaveBeenCalled();
+        });
     });
     
     describe('translate filter:', function () {


### PR DESCRIPTION
Added cascade translations and path solving.

Translation:
A: {
 a1: "Hello world"
}

translate.getTerm("A.a1") will resolve to "Hello world".